### PR TITLE
Handle ResourceNotFound errors gracefully on Read and Delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
+*.info
 
 website/vendor
 


### PR DESCRIPTION
When a resource is not found, or is in a DELETING State, we can remove the resource from Terraform state so that depending on the lifecycle action Terraform can take appropriate steps, or skip unnecessary calls.