### PR TITLE
Bug excessive resource replacement

### DIFF
--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -20,7 +20,7 @@ resource "ambar_data_source" "example_data_source" {
   # See Ambar docs for more details.
   data_source_config = {
     "hostname" : "host",
-    "hostPort" : "5432",
+    "hostPort" : 5432,
     "username" : "username",
     "password" : "password"
     "databaseName" : "postgres",
@@ -43,10 +43,10 @@ resource "ambar_data_source" "example_mysql_data_source" {
   # See Ambar docs for more details.
   data_source_config = {
     "hostname" : "host",
-    "hostPort" : "5432",
+    "hostPort" : 3036,
     "username" : "username",
     "password" : "password"
-    "databaseName" : "postgres",
+    "databaseName" : "mysql",
     "tableName" : "events",
     "publicationName" : "example_pub",
     "partitioningColumn" : "partition",

--- a/examples/resources/ambar_data_source/resource.tf
+++ b/examples/resources/ambar_data_source/resource.tf
@@ -28,10 +28,10 @@ resource "ambar_data_source" "example_mysql_data_source" {
   # See Ambar docs for more details.
   data_source_config = {
     "hostname" : "host",
-    "hostPort" : "5432",
+    "hostPort" : "3036",
     "username" : "username",
     "password" : "password"
-    "databaseName" : "postgres",
+    "databaseName" : "mysql",
     "tableName" : "events",
     "publicationName" : "example_pub",
     "partitioningColumn" : "partition",

--- a/examples/resources/ambar_data_source/resource.tf
+++ b/examples/resources/ambar_data_source/resource.tf
@@ -5,7 +5,7 @@ resource "ambar_data_source" "example_data_source" {
   # See Ambar docs for more details.
   data_source_config = {
     "hostname" : "host",
-    "hostPort" : "5432",
+    "hostPort" : 5432,
     "username" : "username",
     "password" : "password"
     "databaseName" : "postgres",
@@ -28,7 +28,7 @@ resource "ambar_data_source" "example_mysql_data_source" {
   # See Ambar docs for more details.
   data_source_config = {
     "hostname" : "host",
-    "hostPort" : "3036",
+    "hostPort" : 3036,
     "username" : "username",
     "password" : "password"
     "databaseName" : "mysql",

--- a/internal/provider/data_source_resource.go
+++ b/internal/provider/data_source_resource.go
@@ -114,8 +114,6 @@ func doesStateRequireReplace(ctx context.Context, request planmodifier.StringReq
 		response.RequiresReplace = true
 		return
 	}
-
-	return
 }
 
 func (r *dataSourceResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {


### PR DESCRIPTION
Fix bug where Reads were forcing DataSource replacements due to omitting sensitive credential fields triggering a Terraform diff.

Few other issues are also fixed, like failing resource creation when a FAILED state is reached, and also triggering resource replacement if a diff is generated in the FAILED state that would otherwise trigger an update.